### PR TITLE
Add creation of DB parameter-group to template-actions

### DIFF
--- a/Templates/make_confluence_RDS.tmplt.json
+++ b/Templates/make_confluence_RDS.tmplt.json
@@ -109,15 +109,23 @@
     },
     "PgsqlVersion": {
       "AllowedValues": [
+        "10.3",
+        "10.1",
+        "9.6.8",
+        "9.6.6",
+        "9.6.5",
         "9.6.3",
         "9.6.2",
         "9.6.1",
+        "9.5.12",
+        "9.5.10",
+        "9.5.9",
         "9.5.7",
         "9.5.6",
         "9.5.4",
         "9.5.2"
       ],
-      "Default": "9.5.7",
+      "Default": "9.5.12",
       "Description": "The X.Y.Z version of the PostGreSQL database to deploy.",
       "Type": "String"
     },
@@ -144,6 +152,7 @@
           ]
         },
         "DBName": { "Ref": "DbInstanceName" },
+        "DBParameterGroupName": { "Ref": "RDSdbParmGrp" },
         "DBSubnetGroupName": { "Ref": "RDSdbSubnetGroup" },
         "Engine": "postgres",
         "EngineVersion": { "Ref": "PgsqlVersion" },
@@ -157,6 +166,43 @@
         "VPCSecurityGroups": { "Ref": "DbSecurityGroup" }
       },
       "Type": "AWS::RDS::DBInstance"
+    },
+    "RDSdbParmGrp": {
+      "Properties" : {
+        "Description" : "Parameters used to modify database behavior and performance characteristics",
+        "Family" : {
+          "Fn::Join": [
+            "",
+            [
+              "postgres",
+              {
+                "Fn::Select": [
+                  "0",
+                  {
+                    "Fn::Split": [
+                      ".",
+                      { "Ref": "PgsqlVersion" }
+                    ]
+                  }
+                ]
+              },
+              ".",
+              {
+                "Fn::Select": [
+                  "1",
+                  {
+                    "Fn::Split": [
+                      ".",
+                      { "Ref": "PgsqlVersion" }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      },
+      "Type" : "AWS::RDS::DBParameterGroup"
     },
     "RDSdbSubnetGroup": {
       "Properties": {


### PR DESCRIPTION
- parameter-group "family" derived from selected PGSQL DB-version
- currently, no default parameters are overridden or overridable
  within the template. Creation/attachment simply ensures that
  the resultant RDSdb can be tuned without effecting other RDSdbs
  in a given account.
- Revisited version selection-list since it's been a number of
  months since this template was last updated.

Closes #6 